### PR TITLE
Update jenkins job names and mac ctest log name

### DIFF
--- a/dataIngest.sh
+++ b/dataIngest.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-python create_database.py testResults.db --jobs main_nightly_deployment release-next_nightly_deployment
-python workflow.py --database_name testResults.db --jenkins_server https://builds.mantidproject.org --jobs main_nightly_deployment release-next_nightly_deployment
+python create_database.py testResults.db --jobs main_nightly release-next_nightly
+python workflow.py --database_name testResults.db --jenkins_server https://builds.mantidproject.org --jobs main_nightly release-next_nightly
 python update_site.py --database_path testResults.db

--- a/workflow.py
+++ b/workflow.py
@@ -15,7 +15,7 @@ from ctest_parser.ctest_log_parser import CtestOutputParser
 
 os_names_to_log_names = {'Windows': 'ctest_msys.log',
                          'Linux': 'ctest_linux-gnu.log',
-                         'MacOS': 'ctest_darwin22.log'}
+                         'MacOS': 'ctest_darwin24.log'}
 logger = logging.getLogger("workflow")
 logging.basicConfig(level=logging.INFO, stream=sys.stdout)
 


### PR DESCRIPTION
Fixes #2 

Decided it was best to just go into the database and modify the names stored there.
Also modified the name of the mac ctest log because I noticed it was different. Probably would be best to find these using a regex or similar.